### PR TITLE
Fix face_parse.py model path error

### DIFF
--- a/gpeno/face_parse/face_parsing.py
+++ b/gpeno/face_parse/face_parsing.py
@@ -13,7 +13,7 @@ import torch.nn.functional as F
 class FaceParse:
 
 	def __init__(self, base_dir='./', model='ParseNet-latest', device='cuda'):
-		self.mfile = os.path.join(base_dir, 'facerestore_models', model + '.pth')
+		self.mfile = os.path.join(base_dir, 'facedetection', model + '.pth')
 		self.size = 512
 		self.device = device
 		self.MASK_COLORMAP = torch.tensor([0, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 255, 255, 255, 0], device=self.device)


### PR DESCRIPTION
Change the load model directory to the download model directory to resolve the error caused by not finding the model